### PR TITLE
Pin dependencies and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ git clone https://github.com/your-user/openai-responses-api-hub.git
 cd openai-responses-api-hub
 pip install -r requirements.txt
 ```
+This command installs the exact package versions listed in `requirements.txt`.
 
 ## 🛠️ Environment Setup
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-openai
-gradio
-python-dotenv
+openai==1.2.0
+gradio==4.31.1
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- pin versions for openai, gradio and python-dotenv
- clarify that `pip install -r requirements.txt` installs pinned versions

## Testing
- `python -m py_compile utils/openai_client.py`


------
https://chatgpt.com/codex/tasks/task_e_685d9217ec14832093f244cfe5d21a34