### PR TITLE
Add guard for missing API key

### DIFF
--- a/utils/openai_client.py
+++ b/utils/openai_client.py
@@ -12,6 +12,9 @@ def get_response(input_text: str, model: str = "gpt-4o") -> str:
     """
     Sends a prompt to the OpenAI Responses API and returns the assistant's output text.
     """
+    if not OPENAI_API_KEY:
+        raise ValueError("Missing OPENAI_API_KEY environment variable.")
+
     headers = {
         "Authorization": f"Bearer {OPENAI_API_KEY}",
         "Content-Type": "application/json"


### PR DESCRIPTION
## Summary
- raise a clear exception when OPENAI_API_KEY is not configured before issuing requests

## Testing
- python -m compileall utils

------
https://chatgpt.com/codex/tasks/task_e_68ef865b1f148320abadce5170a657d0