### PR TITLE
Modernize OpenAI helper client

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,20 @@ Work through each notebook to explore different API capabilities.
 
 ## 💡 Usage Example
 
-The helper `get_response` function in `utils/openai_client.py` makes it easy to
-query the API from your own scripts:
+The helper `get_response` function in `utils/openai_client.py` now wraps the
+latest `OpenAI` SDK, so you can opt into tools, modalities, or streaming without
+rewriting your scripts:
 
 ```python
 from utils.openai_client import get_response
 
-reply = get_response("Hello, world!")
+# Basic, blocking call
+reply = get_response("Summarize the OpenAI Responses API in 2 sentences.")
 print(reply)
+
+# Stream deltas for a faster-feeling UI experience
+for chunk in get_response("Write a limerick about streaming text", stream=True):
+    print(chunk, end="", flush=True)
 ```
 
 See the notebooks for more detailed examples and workflows.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-openai==1.2.0
+openai==1.51.0
 gradio==4.31.1
 python-dotenv==1.0.1

--- a/utils/openai_client.py
+++ b/utils/openai_client.py
@@ -1,36 +1,100 @@
-import os
-import requests
-from dotenv import load_dotenv
+"""Convenience helpers for calling the OpenAI Responses API."""
 
-# Load environment variables
+from __future__ import annotations
+
+import os
+from collections.abc import Generator, Iterable
+from typing import Any, Dict, List, Optional, Union
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+# Load environment variables eagerly so local .env files Just Work™.
 load_dotenv()
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
+_API_KEY = os.getenv("OPENAI_API_KEY")
 
-def get_response(input_text: str, model: str = "gpt-4o") -> str:
-    """
-    Sends a prompt to the OpenAI Responses API and returns the assistant's output text.
-    """
-    if not OPENAI_API_KEY:
-        raise ValueError("Missing OPENAI_API_KEY environment variable.")
+if not _API_KEY:
+    raise ValueError("Missing OPENAI_API_KEY environment variable.")
 
-    headers = {
-        "Authorization": f"Bearer {OPENAI_API_KEY}",
-        "Content-Type": "application/json"
-    }
+_CLIENT = OpenAI(api_key=_API_KEY)
 
-    payload = {
-        "model": model,
-        "input": input_text
-    }
+ResponseInput = Union[str, List[Dict[str, Any]]]
+
+
+def _extract_text(response: Any) -> str:
+    """Safely pull the first text block from a Responses API payload."""
 
     try:
-        response = requests.post(OPENAI_RESPONSES_URL, headers=headers, json=payload)
-        response.raise_for_status()
-        data = response.json()
+        return response.output[0].content[0].text or ""
+    except (AttributeError, IndexError, TypeError):
+        return ""
 
-        # Parse the output text safely
-        return data.get("output", [{}])[0].get("content", [{}])[0].get("text", "[No text returned]")
-    except Exception as e:
-        return f"[Error]: {str(e)}"
+
+def _stream_text(stream: Any) -> Generator[str, None, None]:
+    """Yield incremental text deltas from a streaming Responses call."""
+
+    with stream as response_stream:
+        for event in response_stream:
+            if event.type == "response.output_text.delta":
+                yield event.delta
+            elif event.type == "response.error":
+                raise RuntimeError(event.error)
+        # Make sure any trailing text is emitted after the stream ends.
+        final_response = response_stream.get_final_response()
+        tail = _extract_text(final_response)
+        if tail:
+            yield tail
+
+
+def get_response(
+    input_text: ResponseInput,
+    *,
+    model: str = "gpt-4o-mini",
+    modalities: Optional[Iterable[str]] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+    stream: bool = False,
+    client: Optional[OpenAI] = None,
+    **extra_params: Any,
+) -> Union[str, Generator[str, None, None]]:
+    """Call the Responses API with sensible defaults.
+
+    Parameters
+    ----------
+    input_text:
+        Either a raw string prompt or the structured list accepted by the
+        Responses API. The helper will pass this through unchanged.
+    model:
+        Model name to target. Defaults to ``gpt-4o-mini`` for cost/latency balance.
+    modalities / tools:
+        Optional lists that expose multimodal generation or tool-calling without
+        rewriting the helper.
+    stream:
+        When ``True`` the function returns a generator that yields text deltas so
+        callers can render output incrementally.
+    client:
+        Override the shared ``OpenAI`` client—useful for dependency injection in
+        tests.
+    extra_params:
+        Any other keyword arguments supported by ``client.responses.create`` will
+        be forwarded untouched (e.g., ``metadata`` or ``max_output_tokens``).
+    """
+
+    active_client = client or _CLIENT
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "input": input_text,
+    }
+
+    if modalities is not None:
+        payload["modalities"] = list(modalities)
+    if tools is not None:
+        payload["tools"] = tools
+    payload.update(extra_params)
+
+    if stream:
+        return _stream_text(active_client.responses.stream(**payload))
+
+    response = active_client.responses.create(**payload)
+    return _extract_text(response)


### PR DESCRIPTION
## Summary
- upgrade the project to use the current OpenAI Python SDK
- rewrite `utils/openai_client.py` to expose streaming, modalities, and tool parameters via the official client
- refresh the README usage example to illustrate the new helper behavior

## Testing
- python -m compileall utils/openai_client.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e1e5279c8320867154fd9562fa70)